### PR TITLE
feat: adding support to enable custom delimiter

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -18,6 +18,12 @@ func (d DoesNotExist) Error() string {
 var invalidObjError = errors.New("invalid object")
 var pathDelimiter = "."
 
+func SetDelimiter(delimiter string) {
+	if len(delimiter) > 0 {
+		pathDelimiter = delimiter
+	}
+}
+
 func tokenizePath(path string) ([]string, error) {
 	var tokens []string
 	for _, stem := range strings.Split(path, pathDelimiter) {

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -10,6 +10,7 @@ var data = map[string]interface{}{
 	"user": map[string]interface{}{
 		"firstname": "seth",
 		"lastname":  "rogen",
+		"address.local": "my temp address",
 	},
 	"age": 35,
 	"filmography": map[string]interface{}{
@@ -50,6 +51,16 @@ func TestGet(t *testing.T) {
 	if _, ok:= err.(DoesNotExist); result != nil || !ok {
 		t.Errorf("does not handle non-existant path correctly")
 	}
+
+	SetDelimiter("|")
+	result, err = Get(data, "user|address.local")
+	if err != nil {
+		t.Errorf("failed to get user|address.local")
+	}
+	if result != "my temp address" {
+		t.Errorf("wrong get value, wanted %v, got %v", "my temp address", result)
+	}
+	SetDelimiter(".")
 }
 
 func TestSet(t *testing.T) {


### PR DESCRIPTION
Hello, Thanks much for the awesome API. It is helping me a lot.

I am sending a feature request to extend the use of delimiter. In my case the required parsed JSON has some of the objects with keys containing same character as default delimiter used (i.e. period/ . )
With this PR end user will be able to set their own delimiter and run queries accordingly. e.g.

jsonpath.SetDelimiter("|") // to set delimiter before use
jsonpath.Get(inputJson, "ValuesFiles|metadata|labels|my.label.name")

Also I am a novice in go and apologize if something is wrong with the PR. 

Please consider this on urgent basis.